### PR TITLE
Colorful error handling (plus template string refactor)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,22 +1,27 @@
 'use strict';
 
-import chalk from 'chalk';
+import { green, yellow, red } from 'chalk';
 
 class Zt {
   
   /** Log normally */
   log(str) {
-    console.log(chalk.green('[log] ') + str);
+    console.log(`${green('[log]')} ${str}`);
   }
   
   /** Log warning */
   warn(str) {
-    console.log(chalk.yellow('[warn] ') + str);
+    console.log(`${yellow('[warn]')} ${str}`);
   }
   
   /** Log error */
   error(err) {
-    console.log(chalk.red('[error] ') + err);
+    if (err instanceof Error) {
+      console.log(`${red(`[${err.name || 'Error'}]`)} ${yellow(err.message || 'Unexpected error')}`)
+      return;
+    }
+    
+    console.log(`${red('[error]')} ${err}`);
   }
   
 }


### PR DESCRIPTION
Handles errors colorfully:

``` javascript
const err = new TypeError('Foo is not bar');
zt.error(err);
```

![image](https://cloud.githubusercontent.com/assets/6251703/14100337/f0ad11c0-f549-11e5-8d28-47a931a20205.png)
